### PR TITLE
fix a memory leak.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.o
+*.gcno
 bin/*
+**/*/coverage
+.vscode

--- a/src/parse_playlist.c
+++ b/src/parse_playlist.c
@@ -74,6 +74,7 @@ int parse_master_tag(const char *src, size_t size, master_t *dest)
         char* path = NULL;
         pt += parse_line_to_str(pt, &path, size - (pt - src));
         path_combine(&stream_inf->uri, dest->uri, path);
+        if (path) hls_free(path);
 
         stream_inf_list_t *next = &dest->stream_infs;
 

--- a/src/write.c
+++ b/src/write.c
@@ -223,6 +223,8 @@ HLSCode hlswrite_master(char **dest, int *dest_size, master_t *master)
     }
 
     page_to_str(root, dest, dest_size);
+    
+    free_page_root(root);
 
     return HLS_OK;
 }
@@ -336,6 +338,8 @@ HLSCode hlswrite_media(char **dest, int *dest_size, media_playlist_t *playlist)
     ADD_TAG_IF_TRUE(EXTXENDLIST, playlist->end_list);
     page_to_str(root, dest, dest_size);
 
+    free_page_root(root);
+
     return HLS_OK;
 }
 
@@ -367,6 +371,16 @@ page_t* create_page(page_t *page)
     }
 
     return new_page;
+}
+
+void free_page_root(page_t *root) {
+    page_t * freed = root; 
+    while (freed) {
+        hls_free(freed->buffer);
+        page_t * curr = freed;
+        freed = freed->next;
+        hls_free(curr);
+    }
 }
 
 page_t *pgprintf(page_t *page, const char *format, ...)

--- a/src/write.h
+++ b/src/write.h
@@ -17,6 +17,8 @@ typedef struct page {
 } page_t;
 
 page_t* create_page(page_t *page);
+void free_page_root(page_t *root);
+
 page_t* write_to_page(page_t *page, const char *buffer, int size);
 page_t* pgprintf(page_t *page, const char *format, ...);
 void page_to_str(page_t *page, char **dest, int *dest_size);


### PR DESCRIPTION
Facing random crash when dealing with M3U8 files with thousands of segments. 

Used valgrind to track this two memory leaks: 

"path" is allocated on heap and needs to be released after usage.

"page_t" objects, which are used as the memory buffer for writing out M3U8, also needs to be released when finished.